### PR TITLE
Update hands-on link

### DIFF
--- a/readme.adoc
+++ b/readme.adoc
@@ -14,7 +14,7 @@ This content is brought to you by http://developers.redhat.com - Register today!
 
 - Download the ebook "Introducing Istio Service Mesh for Microservices" for FREE at https://developers.redhat.com/books/introducing-istio-service-mesh-microservices/.
 
-- If you are in a hurry and want to get hands-on with Istio insanely fast, just go to http://learn.openshift.com/servicemesh[http://learn.openshift.com/servicemesh] and start instantly.
+- If you are in a hurry and want to get hands-on with Istio insanely fast, just go to https://developers.redhat.com/topics/service-mesh and start instantly.
 
 
 


### PR DESCRIPTION
Change service mesh link from [1] to [2] because the first URL is broken

> [1] http://learn.openshift.com/servicemesh
> [2] https://developers.redhat.com/topics/service-mesh